### PR TITLE
Fixing an issue where connection would be called twice (and throw an exception on binding a socket twice)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Node.js implementation of the NAT Port Mapping Protocol (a.k.a NAT-PMP).
  *
@@ -89,6 +88,9 @@ exports.Client = Client;
 
 Client.prototype.connect = function () {
   debug('Client#connect()');
+  if (this._connecting) {
+    return false;
+  }
   this._connecting = true;
   this.socket.bind(exports.CLIENT_PORT);
 };


### PR DESCRIPTION
On node 0.10.8 the example script would throw:

```
dgram.js:163
    throw new Error('Socket is already bound');
      ^
Error: Socket is already bound
    at Socket.bind (dgram.js:163:11)
    at Client.connect (/test.js:94:15)
    at /node_modules/nat-pmp/index.js:57:12
    at process._tickCallback (node.js:415:13)
    at Function.Module.runMain (module.js:499:11)
    at startup (node.js:119:16)
    at node.js:901:3
```
