### PR TITLE
Do not try to process request when client is closed

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,6 +198,10 @@ Client.prototype.portUnmapping = function (opts, cb) {
 Client.prototype._next = function () {
   debug('Client#_next()');
   var req = this._queue[0];
+  if (!this.socket) {
+    debug('_next: client is closed');
+    return;
+  }
   if (!req) {
     debug('_next: nothing to process');
     return;


### PR DESCRIPTION
When I call close with pending requests, `_next` is called with a null socket and it tries to call `connect()` instead of skipping the request.

This PR checks the socket before sending the request.