### PR TITLE
Allow address reuse

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ function Client (gateway) {
   this.listening = false;
   this.gateway = gateway;
 
-  this.socket = dgram.createSocket('udp4');
+  this.socket = dgram.createSocket({type: 'udp4', reuseAddr: true});
   on('listening', this);
   on('message', this);
   on('close', this);


### PR DESCRIPTION
This enables multiple processes to use node-pmp

Not having address reuse breaks running multiple processes that need to open ports.